### PR TITLE
Simplify BCD conversion by staying in integers

### DIFF
--- a/lib/nerves_time/rtc/nxp/bcd.ex
+++ b/lib/nerves_time/rtc/nxp/bcd.ex
@@ -1,41 +1,34 @@
 defmodule NervesTime.RTC.NXP.BCD do
   @moduledoc """
-  Helpers for converting to and from register values
+  Helpers for converting to and from binary coded decimal (BCD)
+
+  BCD is commonly used in Real-time clock chips for historical reasons. See
+  [wikipedia.org/wiki/Binary-coded_decimal](https://en.wikipedia.org/wiki/Binary-coded_decimal)
+  for a good background on BCD. The BCD implementation here is referred to as
+  "Packed BCD" in the article.
   """
 
   @doc "Convert a 8 bit integer value to a BCD binary"
+  @spec int_to_bcd(0..99) :: 0..0x99
   def int_to_bcd(value) when value <= 9 do
-    <<0::integer-4, value::integer-4>>
+    value
   end
 
   def int_to_bcd(value) when value <= 99 do
     tens = div(value, 10)
     units = rem(value, 10)
-    <<tens::integer-4, units::integer-4>>
+    16 * tens + units
   end
 
-  @doc "Convert a 8 bit bcd bitstring to an integer"
-  def bcd_to_int(value, power \\ 10)
+  @doc "Convert a 8 bit bcd-encoded value to an integer"
+  @spec bcd_to_int(0..0x99) :: 0..99
+  def bcd_to_int(value) when value <= 9 do
+    value
+  end
 
-  # 5 bit bcd
-  def bcd_to_int(<<tens::integer-1, units::integer-4>>, pow),
-    do: bcd_to_int(tens, units, pow)
-
-  # 6 bit bcd
-  def bcd_to_int(<<tens::integer-2, units::integer-4>>, pow),
-    do: bcd_to_int(tens, units, pow)
-
-  # 7 bit bcd
-  def bcd_to_int(<<tens::integer-3, units::integer-4>>, pow),
-    do: bcd_to_int(tens, units, pow)
-
-  # 8 bit bcd
-  def bcd_to_int(<<tens::integer-4, units::integer-4>>, pow),
-    do: bcd_to_int(tens, units, pow)
-
-  defp bcd_to_int(tens, units, pow) when units >= pow,
-    do: bcd_to_int(tens, units, pow * 10)
-
-  defp bcd_to_int(tens, units, pow),
-    do: tens * pow + units
+  def bcd_to_int(value) do
+    tens = div(value, 16)
+    units = rem(value, 16)
+    10 * tens + units
+  end
 end

--- a/test/nerves_time/rtc/nxp/bcd_test.exs
+++ b/test/nerves_time/rtc/nxp/bcd_test.exs
@@ -1,13 +1,14 @@
 defmodule NervesTime.RTC.NXP.BCDTest do
   use ExUnit.Case
-  use PropCheck
   alias NervesTime.RTC.NXP.BCD
 
-  property "conversion is symmetrical" do
-    forall int <- integer(0, 99) do
-      bcd = BCD.int_to_bcd(int)
-      assert BCD.bcd_to_int(bcd) == int
-      assert match?(<<_::8>>, bcd)
+  test "all values convert" do
+    for tens <- 0..9, ones <- 0..9 do
+      number = tens * 10 + ones
+      bcd = tens * 16 + ones
+
+      assert BCD.int_to_bcd(number) == bcd
+      assert BCD.bcd_to_int(bcd) == number
     end
   end
 end


### PR DESCRIPTION
This also refactors the register-to-datetime conversion to a separate
function to make it a little easier to read.