### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NervesTime.RTC.NXP
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_time_rtc_nxp.svg "Hex version")](https://hex.pm/packages/nerves_time_rtc_nxp)
-[![API docs](https://img.shields.io/hexpm/v/nerves_time_rtc_nxp.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_time_rtc_nxp/NervesTime.RTC.NXP.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_time_rtc_nxp.svg?label=hexdocs "API docs")](https://nerves-time-rtc-nxp.hexdocs.pm/NervesTime.RTC.NXP.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-time/nerves_time_rtc_nxp/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-time/nerves_time_rtc_nxp/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-time/nerves_time_rtc_nxp)](https://api.reuse.software/info/github.com/nerves-time/nerves_time_rtc_nxp)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-time-rtc-nxp.hexdocs.pm/NervesTime.RTC.NXP.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>